### PR TITLE
fix: trim table when no annotation legend

### DIFF
--- a/R/pheatmap.r
+++ b/R/pheatmap.r
@@ -503,6 +503,9 @@ heatmap_motor = function(matrix, border_color, cellwidth, cellheight, tree_col, 
         res = gtable_add_grob(res, elem, t = t, l = 5, b = 5, clip = "off", name = "legend")
     }
     
+    # Remove unused cols and rows in the table
+    res = gtable_trim(res)
+    
     return(res)
 }
 


### PR DESCRIPTION
Very simple quick fix that reduces the lost space on the right of the pheatmap if there is no annotation legend.

The only good reason not to do that is if a higher level function rely on the gtable layout being 5x6.