### PR TITLE
pheatmap class with grid.draw and print methods

### DIFF
--- a/R/pheatmap.r
+++ b/R/pheatmap.r
@@ -1042,7 +1042,18 @@ pheatmap = function(mat, color = colorRampPalette(rev(brewer.pal(n = 7, name = "
         grid.draw(gt)
     }
     
-    invisible(list(tree_row = tree_row, tree_col = tree_col, kmeans = km, gtable = gt))
+    invisible(structure(list(tree_row = tree_row, tree_col = tree_col, kmeans = km, gtable = gt), class = "pheatmap"))
 }
 
 
+##' @method grid.draw pheatmap
+##' @export
+grid.draw.pheatmap <- function(x, recording = TRUE) {
+    grid.draw(x$gtable)
+}
+
+##' @method print pheatmap
+##' @export
+print.pheatmap <- function(x, ...) {
+    grid.draw(x)
+}


### PR DESCRIPTION
re-PR, <https://github.com/raivokolde/pheatmap/pull/42>. 

+ add `pheatmap` class attribute
+ define `grid.draw` method, so that `ggplot2::ggsave` can be used to export `pheatmap` object
+ define `print` method, so that the heatmap will be drawn interactively

To make it simple for you to read the diff, I didn't update roxygen (namespace for grid and print method).

