### PR TITLE
Call grid.newpage() in print.pheatmap()

### DIFF
--- a/R/pheatmap.r
+++ b/R/pheatmap.r
@@ -1111,5 +1111,6 @@ grid.draw.pheatmap <- function(x, recording = TRUE) {
 #' @method print pheatmap
 #' @export
 print.pheatmap <- function(x, ...) {
+    grid.newpage()
     grid.draw(x)
 }


### PR DESCRIPTION
This PR fixes #109 by making `print.pheatmap()` call `grid.newpage()` before drawing the heatmap.

I left `grid.draw.pheatmap()` unchanged, since it seems useful for drawing a `pheatmap` object within an existing grid layout.

Fixes #109